### PR TITLE
Set description of website

### DIFF
--- a/website/public/index.html
+++ b/website/public/index.html
@@ -8,9 +8,9 @@
 
   <link rel="stylesheet" href="style.css">
 
-  <meta name="description" content="Page description">
+  <meta name="description" content="A simple, private tool to help pick a baby name">
   <meta property="og:title" content="Nom de Bébé">
-  <meta property="og:description" content="Page description">
+  <meta property="og:description" content="A simple, private tool to help pick a baby name">
   <meta property="og:image" content="https://nomdebebe.app/image.jpg">
   <meta property="og:image:alt" content="Image description">
   <meta property="og:locale" content="en_CA">


### PR DESCRIPTION
I replaced the placeholder that appeared when I shared the website URL in Mattermost:

> ![image](https://user-images.githubusercontent.com/2071331/140557768-e1de89f6-e91c-4414-aaea-1378b8844207.png)
